### PR TITLE
Documentation and metadata fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ $ pip install neonutilities
 
 ```
 import neonutilities as nu
+import os
 
 bird = nu.load_by_product(dpid="DP1.10003.001",
 			site="RMNP",

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ bird = nu.load_by_product(dpid="DP1.10003.001",
 			package="expanded",
 			release="RELEASE-2024",
 			token=os.environ.get("NEON_TOKEN"))
-							   
+
 nu.by_tile_aop(dpid="DP3.30015.001",
 		site="WREF",
-		year=2022,
+		year=2021,
 		easting=[571000,578000],
 		northing=[5079000,5080000],
 		savepath="filepath on your machine",
@@ -54,4 +54,3 @@ Disclaimer
 ---
 
 Information and documents contained within this repository are available as-is. Codes or documents, or their use, may not be supported or maintained under any program or service and may not be compatible with data currently available from the NEON Data Portal.
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ authors = [
 description="A package for accessing and wrangling data generated and published by the National Ecological Observatory Network."
 readme = "README.md"
 requires-python = ">=3.9"
+urls.Documentation = "https://neon-utilities-python.readthedocs.io/en/latest/"
+urls.Source = "https://github.com/NEONScience/NEON-utilities-python/"
 dependencies = [
     "importlib-resources",
     "pandas",

--- a/src/neonutilities/unzip_and_stack.py
+++ b/src/neonutilities/unzip_and_stack.py
@@ -1098,6 +1098,7 @@ def stack_by_table(filepath,
     Example
     ------------------
     To stack PAR data (DP1.00024.001) downloaded from the NEON data portal
+
     >>> pardat = stack_by_table("/filepath/NEON_par.zip")
 
     Created on Tue Mar 5 2024


### PR DESCRIPTION
Fixes to 4 small things I came across while conducting pyOpenSci review https://github.com/pyOpenSci/software-submission/issues/213

- Add a missing import in a README example
- Change the download year so that README example actually downloads data
- Whitespace fix to properly render function example
- Add urls for docs and source to pyproject.toml (and therefore to PyPI)